### PR TITLE
Fix stats api when no stats file exists.

### DIFF
--- a/AppInit.cs
+++ b/AppInit.cs
@@ -35,6 +35,7 @@ namespace JacRed
         }
         #endregion
 
+        public string torrentsStatFile = "Data/temp/stats.json";
 
         public string listenip = "any";
 

--- a/Controllers/StatsController.cs
+++ b/Controllers/StatsController.cs
@@ -16,7 +16,10 @@ namespace JacRed.Controllers
 
             if (string.IsNullOrWhiteSpace(trackerName))
             {
-                return Content(System.IO.File.ReadAllText("Data/temp/stats.json"));
+                if (System.IO.File.Exists(AppInit.conf.torrentsStatFile))
+                    return Content(System.IO.File.ReadAllText(AppInit.conf.torrentsStatFile));
+                else
+                    return Content(string.Empty);
             }
             else
             {

--- a/Engine/StatsCron.cs
+++ b/Engine/StatsCron.cs
@@ -71,7 +71,7 @@ namespace JacRed.Engine
                         }
                     }
 
-                    File.WriteAllText("Data/temp/stats.json", JsonConvert.SerializeObject(stats.OrderByDescending(i => i.Value.alltorrents).Select(i => new
+                    File.WriteAllText(AppInit.conf.torrentsStatFile, JsonConvert.SerializeObject(stats.OrderByDescending(i => i.Value.alltorrents).Select(i => new
                     {
                         trackerName = i.Key,
                         lastnewtor = i.Value.lastnewtor.ToString("dd.MM.yyyy"),


### PR DESCRIPTION
Fix stats api when no stats file exists.
Move stats file full name to AppInin config section.