### PR TITLE
Fix HDR/SDR filter. Need to run ip/dev/UpdateDetails. Closes #10

### DIFF
--- a/Engine/FileDB/FileDB.cs
+++ b/Engine/FileDB/FileDB.cs
@@ -253,7 +253,7 @@ namespace JacRed.Engine
 
             #region videotype
             t.videotype = "sdr";
-            if (Regex.IsMatch(titlelower, "(\\[| )hdr( |\\]|,|$)") || Regex.IsMatch(titlelower, "(10-bit|10 bit|10-бит|10 бит)"))
+            if ((Regex.IsMatch(titlelower, "(\\[| )hdr?(10\\+?)( |\\]|,|$)") || Regex.IsMatch(titlelower, "(10-bit|10 bit|10-бит|10 бит)")) && !Regex.IsMatch(titlelower, "(\\[| )sdr( |\\]|,|$)"))
             {
                 t.videotype = "hdr";
             }


### PR DESCRIPTION
Fix HDR/SDR filter. Need to run ip/dev/UpdateDetails. Closes #10
Заодно добавил фильтр, чтоб убрать SDR из фильтра HDR. Битность не равна разрешению.
Нужно вызвать ip/dev/UpdateDetails на сервере жакета, т.к. стоит фильтрация по ip 127.0.0.1 и вызов делать можно только локально.

![Working HDR filter](https://github.com/user-attachments/assets/3dde10f5-6493-4811-b90e-64ab0dda1856)
